### PR TITLE
Satz war nicht übersetzt.

### DIFF
--- a/data/localized/de_patch/text/conversations/px4/px4_cv_ponamu.stringtable
+++ b/data/localized/de_patch/text/conversations/px4/px4_cv_ponamu.stringtable
@@ -28,7 +28,7 @@ Vor dir steht ein Aumaua mit verfilzten Haaren und zerrissenen Kleidern mit ausg
     </Entry>
     <Entry>
       <ID>5</ID>
-      <DefaultText />
+      <DefaultText>„Wer bist du?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>


### PR DESCRIPTION
Satz fehlte. 